### PR TITLE
feat(pr): Add option to automatically create PR

### DIFF
--- a/pr-buddy.sh
+++ b/pr-buddy.sh
@@ -165,3 +165,18 @@ echo "✨ Here is the suggested PR Title and Description:"
 echo "------------------------------"
 echo "$generated_text"
 echo "------------------------------"
+
+# --- Step 6: Automatically create PR (optional) ---
+read -p "Do you want to create a GitHub PR with this? (y/N): " create_pr
+if [[ "$create_pr" =~ ^[Yy]$ ]]; then
+    # Extract PR title
+    pr_title=$(echo "$generated_text" | sed -n '/\*\*PR Title:/,/PR Description:/p' \
+        | grep -E '^`.*`$' \
+        | sed 's/^`//;s/`$//')
+
+    # Extract PR body (everything after "PR Description:")
+    pr_body=$(echo "$generated_text" | awk '/\*\*PR Description:/{flag=1; next} flag {print}')
+
+    echo "📤 Creating PR: \"$pr_title\"..."
+    gh pr create --base "$to_branch" --head "$from_branch" --title "$pr_title" --body "$pr_body"
+fi

--- a/pr-buddy.sh
+++ b/pr-buddy.sh
@@ -175,7 +175,7 @@ if [[ "$create_pr" =~ ^[Yy]$ ]]; then
         | sed 's/^`//;s/`$//')
 
     # Extract PR body (everything after "PR Description:")
-    pr_body=$(echo "$generated_text" | awk '/\*\*PR Description:/{flag=1; next} flag {print}')
+    pr_body=$(echo "$ai_response" | sed -n '/^```markdown$/,/^```$/p' | sed '1d;$d')
 
     echo "📤 Creating PR: \"$pr_title\"..."
     gh pr create --base "$to_branch" --head "$from_branch" --title "$pr_title" --body "$pr_body"

--- a/pr-buddy.sh
+++ b/pr-buddy.sh
@@ -175,7 +175,7 @@ if [[ "$create_pr" =~ ^[Yy]$ ]]; then
         | sed 's/^`//;s/`$//')
 
     # Extract PR body (everything after "PR Description:")
-    pr_body=$(echo "$ai_response" | sed -n '/^```markdown$/,/^```$/p' | sed '1d;$d')
+    pr_body=$(echo "$generated_text" | sed -n '/^```markdown$/,/^```$/p' | sed '1d;$d')
 
     echo "📤 Creating PR: \"$pr_title\"..."
     gh pr create --base "$to_branch" --head "$from_branch" --title "$pr_title" --body "$pr_body"


### PR DESCRIPTION
### ✨ New Functionality

*   Adds an optional step that prompts the user (`read -p`) to create a GitHub PR after the title and description have been generated. Closes #1
*   Parses the generated text to extract the PR title using `sed` and the PR body using `awk`.
*   Utilizes the GitHub CLI (`gh pr create`) to open the pull request with the extracted title and body, targeting the previously defined base and head branches.