### PR TITLE
feat(pr): auto-assign PR to creator

### DIFF
--- a/pr-buddy.sh
+++ b/pr-buddy.sh
@@ -284,7 +284,12 @@ if [[ ! "${create_pr}" =~ ^[Nn]$ ]]; then
     fi
     echo "📤 Creating PR: \"$pr_title\"..."
     # The variables are already clean and ready to use
-    gh pr create --base "$to_branch" --head "$from_branch" --title "$pr_title" --body "$pr_body"
+    gh pr create \
+      --base "$to_branch" \
+      --head "$from_branch" \
+      --title "$pr_title" \
+      --body "$pr_body" \
+      --assignee "$(gh api user --jq '.login')"
 fi
 
 echo "✅ Done."


### PR DESCRIPTION
### ✨ New Functionality
*   **Auto-assign PR Creator:** The pull request creation process now automatically assigns the creator as the assignee. This is accomplished by adding the `--assignee` flag to the `gh pr create` command and retrieving the current user's login with `gh api user --jq '.login'`. This improves PR tracking and workflow efficiency.
    *   **Closes #14**