### PR TITLE
fix(prompt): Ensure unique issue references in description

### DIFF
--- a/pr-buddy.sh
+++ b/pr-buddy.sh
@@ -88,7 +88,7 @@ The JSON object must have the following structure:
 2.  `description` (string):
     *   This string must contain the full technical description formatted in Markdown.
     *   Do not add any introductory sentences. Start directly with the first relevant category heading.
-    *   Group technical changes into the following categories using `###` (H3) headings. Only include categories with relevant changes.
+    *   Group technical changes into the following categories using `###` (H3) headings. Only include categories with relevant changes:
         * `### ✨ New Functionality`
         * `### 🛠️ Refactoring & Architectural Changes`
         * `### 🐛 Bug Fixes`
@@ -97,7 +97,11 @@ The JSON object must have the following structure:
     *   Under each category, list each major change using the following nested structure:
         *   Start with a primary bullet point (`*`). The line must begin with a **bolded, descriptive title** that summarizes the change, followed by a colon.
         *   Immediately after the colon, write a detailed paragraph explaining the change, its impact, and the technical reasoning.
-        *   On a new line, add a nested and **bolded** bullet point that contains only the issue reference. Crucially, each issue must be on its own separate line and in its own bullet point to ensure GitHub can parse them correctly.
+        *   On a new line, add a nested and **bolded** bullet point that contains only the issue reference.
+    *   **Important Rules:**
+        *   Each issue number (e.g., `#26`) may only appear **once** in the entire PR description. If multiple changes relate to the same issue, merge them into a single bullet point that collectively describes all relevant changes for that issue.
+        *   Do **not** repeat the same issue reference under multiple bullet points or categories.
+        *   When merging related changes, clearly describe all technical updates under a unified description.
     *   **Example of the required format for a single item:**
         ```markdown
         *   **Sequential Image Processing:** The multi-shot camera has been re-architected to process images sequentially rather than in parallel. This significantly reduces memory pressure and resolves crashes that occurred when capturing a large number of photos (15+) in a single session.


### PR DESCRIPTION
### 🐛 Bug Fixes

*   **Prevent Duplicate Issue References:** Updated the internal prompt instructions to enforce that each issue number can only be referenced once in the generated PR description. The new rules mandate merging all changes related to a single issue into one comprehensive bullet point, preventing the same issue from appearing under multiple items or categories. This resolves a bug where the model would sometimes create redundant references, leading to cluttered and incorrect issue linking.
    *   **Fixes #16**