### PR TITLE
fix(summary): Separate selected labels with commas in output

### DIFF
--- a/issue-buddy.sh
+++ b/issue-buddy.sh
@@ -92,7 +92,9 @@ else
     echo "Body: (none)"
 fi
 if ((${#selected_labels[@]} > 0)); then
-    echo "Labels: ${selected_labels[*]}"
+    labels_joined=$(printf "%s, " "${selected_labels[@]}")
+    labels_joined=${labels_joined%, }
+    echo "Labels: ${labels_joined}"
 else
     echo "Labels: (none)"
 fi


### PR DESCRIPTION
### 🐛 Bug Fixes
*   **Format Selected Labels in Summary:** Modified the issue summary output generation logic to ensure that selected labels are properly separated by a comma and a space. Previously, using `${selected_labels[*]}` relied on the default Internal Field Separator (IFS), typically resulting in only space separation which hindered readability. The updated script uses `printf "%s, "` to join elements, followed by parameter expansion (`${labels_joined%, }`) to cleanly remove the trailing comma and space.
    *   **Fixes #39**