### PR TITLE
fix(bump): Fix version increment arithmetic

### DIFF
--- a/flutter/bump-version.sh
+++ b/flutter/bump-version.sh
@@ -52,16 +52,16 @@ read -p "Bump which part? [M]ajor/[m]inor/[p]atch (default: patch): " bump_choic
 
 case "$bump_choice" in
     M|major|MAJOR)
-        ((major++))
+        ((major+=1))
         minor=0
         patch=0
         ;;
     m|minor|MINOR)
-        ((minor++))
+        ((minor+=1))
         patch=0
         ;;
     ""|p|P|patch|PATCH)
-        ((patch++))
+        ((patch+=1))
         ;;
     *)
         echo "Error: Unknown choice '$bump_choice'."


### PR DESCRIPTION
### 🐛 Bug Fixes
*   **Corrected Version Increment Logic:** The shell script responsible for bumping major, minor, and patch versions has been updated to use the `((var+=1))` arithmetic operator instead of `((var++))`. This change addresses an intermittent error that occurred during the version bumping process, particularly when incrementing the patch version. While both operators typically perform an increment, `((var+=1))` provides a more robust and consistently reliable method for numerical incrementation across different shell environments, resolving the prior issue where the increment sometimes failed or produced incorrect results.
    *   **Fixes #55**