### PR TITLE
feat(github): Create script to edit issues interactively

### DIFF
--- a/github/issue-edit.sh
+++ b/github/issue-edit.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# issue-edit.sh: Helper to edit GitHub issues from the terminal.
+# issue-edit.sh: A script to edit GitHub issues from the terminal,
+# with prefilled inputs for faster updates.
 
 set -euo pipefail
 
@@ -142,10 +143,14 @@ else
     selected_labels=("${current_labels[@]}")
 fi
 
-read -rp "Change state (open/closed/leave blank to keep current): " new_state
+read -rp "Change state ([o]pen/[c]losed, leave blank to keep current): " new_state
 new_state=$(echo "$new_state" | tr '[:upper:]' '[:lower:]')
 if [[ -z "$new_state" ]]; then
     new_state="$current_state"
+elif [[ "$new_state" == "o" ]]; then
+    new_state="open"
+elif [[ "$new_state" == "c" ]]; then
+    new_state="closed"
 fi
 
 # --- Assemble gh issue edit command ---


### PR DESCRIPTION
### ✨ New Feature
*   **Interactive GitHub Issue Editor:** Develop a new Bash script `github/issue-edit.sh` that provides a command-line interface for editing GitHub issues. This script streamlines the issue update process by pre-filling current issue data (title, body, labels, state) and offering interactive prompts for changes. It supports updating the title, body (with `$EDITOR` integration), labels (with `fzf` support for multi-selection), and issue state (open/closed). The script leverages `gh` CLI and `jq` for efficient interaction with the GitHub API and JSON parsing, enhancing the workflow for issue management directly from the terminal.
    *   **Fixes #57**