### PR TITLE
chore(versioning): Increment build number during version bump

### DIFF
--- a/flutter/bump-version.sh
+++ b/flutter/bump-version.sh
@@ -69,6 +69,11 @@ case "$bump_choice" in
         ;;
 esac
 
+# Bumping the build number too if it exists.
+if [[ -n "$build_number" ]]; then
+    ((build_number+=1))
+fi
+
 new_version="${major}.${minor}.${patch}"
 if [[ -n "$build_number" ]]; then
     new_version+="+${build_number}"


### PR DESCRIPTION
### 🧹 Maintenance & Chores
*   **Increment build number in bump script**: The `bump-version.sh` script has been updated to automatically increment the build number when a version bump is performed, provided a build number already exists. This ensures that each new build generated through the script has a unique and increasing build identifier, which is crucial for distinguishing different iterations of the same semantic version.